### PR TITLE
Switch from deprecated conv_to<T>::from() to as_scalar()

### DIFF
--- a/src/agenbag-gradients.cpp
+++ b/src/agenbag-gradients.cpp
@@ -97,7 +97,7 @@ NumericMatrix engine7_agenbag2(arma::mat data, int threshold = 3){
 
         arma::mat quantVal = arma::stddev(miniMatrix2.elem(arma::find_finite(miniMatrix2)), 0, 0);
 
-        emptyData(i, j) = arma::conv_to < double >::from(quantVal);
+        emptyData(i, j) = arma::as_scalar(quantVal);
       }
     }
   }

--- a/src/convolution-with-quantiles.cpp
+++ b/src/convolution-with-quantiles.cpp
@@ -82,7 +82,7 @@ NumericMatrix engine2_convWithQuantiles(arma::mat data, arma::mat kernel, arma::
         arma::mat quantVal = arma::quantile(miniMatrix2.elem(arma::find_finite(miniMatrix2)), probs);
 
         // Replace the quantile value in the corresponding cell of the output matrix
-        emptyData(i, j) = arma::conv_to < double >::from(quantVal);
+        emptyData(i, j) = arma::as_scalar(quantVal);
       }
     }
   }

--- a/src/quantile-filter.cpp
+++ b/src/quantile-filter.cpp
@@ -64,7 +64,7 @@ NumericMatrix engine4_quantileFilter(arma::mat data, NumericVector radius, arma:
 
         arma::mat quantVal = arma::quantile(miniMatrix2.elem(arma::find_finite(miniMatrix2)), probs);
 
-        emptyData(i, j) = arma::conv_to < double >::from(quantVal);
+        emptyData(i, j) = arma::as_scalar(quantVal);
       }
     }
   }


### PR DESCRIPTION
Armadillo 15.0.* now makes C++14 the minimum compilation standard, which also means I can no-longer add the suppression of deprecation warnings (which used a macro before and now use a C++14 or later attribute). For most packages, adapting to it can be very simple, and yours is one of them -- in fact it is just three statements. In the patch below we simply update this as now required by Armadillo 15.0.x.  

Please see issues [#475](https://github.com/RcppCore/RcppArmadillo/issues/475) and below at the RcppArmadillo GitHub repo for context, and notably [#491](https://github.com/RcppCore/RcppArmadillo/issues/491) for this second wave of PRs and patches (following one for moving away from C++11, something your package does not need). It would be terrific if you could make an upload to CRAN 'soon' to remove the deprecation warning. Please do not hesitate to reach out if I can assist in any way or clarify matters -- see also [this blog post from yesterday](http://dirk.eddelbuettel.com/blog/2025/10/10#rcpparmadillo_15_transition_office_hours) and the [corresponding email to the r-package-devel list](https://stat.ethz.ch/pipermail/r-package-devel/2025q4/012051.html) -- I can offer help in informal 'office hours' over zoom or google meet.